### PR TITLE
github-actions: ubuntu-20.04 will be fully retired by April 1, 2025.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   primary:
     # see https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js


### PR DESCRIPTION
See github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes