### PR TITLE
github-actions: Artifact actions v3 brownouts by January 30th, 2025

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run tests
         run: npm run test
       - name: Store snapshots from tests
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: snapshots


### PR DESCRIPTION
See https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#artifact-actions-v3-brownouts